### PR TITLE
[:pencil:] Fix i3wm documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,10 +99,10 @@ Example i3wm Keybindings
 .. code:: bash
 
    # select entry using dmenu, then send password to keyboard
-   bindsym $mod+p exec --no-startup-id "ph type --prog dmenu"
+   bindsym $mod+p exec "ph type --prog dmenu"
 
    # select entry using dmenu, then send username + password to keyboard
-   bindsym $mod+Shift+p exec --no-startup-id "ph type --tabbed --prog dmenu"
+   bindsym $mod+Shift+p exec "ph type --tabbed --prog dmenu"
 
 Testing and Development
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,9 @@ Example i3wm Keybindings
 .. code:: bash
 
    # select entry using dmenu, then send password to keyboard
-   bindsym $mod+p exec "ph type dmenu"
+   bindsym $mod+p exec --no-startup-id "ph type"
    # select entry using dmenu, then send username + password to keyboard
-   bindsym $mod+Shift+p exec "ph type dmenu --tabbed"
+   bindsym $mod+Shift+p exec --no-startup-id "ph type --tabbed"
 
 Testing and Development
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,10 @@ Example i3wm Keybindings
 .. code:: bash
 
    # select entry using dmenu, then send password to keyboard
-   bindsym $mod+p exec --no-startup-id "ph type"
+   bindsym $mod+p exec --no-startup-id "ph type --prog dmenu"
+
    # select entry using dmenu, then send username + password to keyboard
-   bindsym $mod+Shift+p exec --no-startup-id "ph type --tabbed"
+   bindsym $mod+Shift+p exec --no-startup-id "ph type --tabbed --prog dmenu"
 
 Testing and Development
 -----------------------


### PR DESCRIPTION
Kind:
- Fix new version syntax (`ph type dmenu` does not exist anymore).
- i3 `exec` needs `--no-startup-id` to have working keyboard typing