### PR TITLE
Remove future from the dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "pykeepass>=4.0.3",
         "pykeepass_cache",
         "colorama",
-        "future",
         "pyotp",
         "qrcode",
     ],


### PR DESCRIPTION
As of c2e701c, Python2 is no longer supported, and uses of the "future" package, which formerly provided a compatibility layer, have been dropped.

 However, "future" is still listed as a dependency in `setup.py`, despite not being used, (at least as far as I can tell).  This PR drops this unnecessary dependency.

See also #67 