### PR TITLE
Improve graphical password dialog wording (closes #71)

### DIFF
--- a/passhole/passhole.py
+++ b/passhole/passhole.py
@@ -412,7 +412,7 @@ def open_database(
                 log.debug('Detected non-interactive shell')
                 try:
                     p = subprocess.Popen(
-                        ["zenity", "--entry", "--hide-text", "--text='{}'".format(prompt)],
+                        ["zenity", "--password", "--title='{}'".format(prompt)],
                         stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE,
                         stderr=open(os.devnull, 'w'),


### PR DESCRIPTION
closes #71

Use explicit password dialog from zenity for a more user-friendly prompt.